### PR TITLE
Removed need for Clear-Host

### DIFF
--- a/IsePester.psm1
+++ b/IsePester.psm1
@@ -1,43 +1,6 @@
 function Add-PesterMenu {
-
-    $sb = {
-    
-        if(!$psISE.CurrentFile.IsUntitled) {
-            $psISE.CurrentFile.Save()
-
-            $fileName = $psISE.CurrentFile.FullPath
-            
-            if($filename -notmatch '\.tests\.') {
-    
-                $parts = $filename -split '\.'    
-                $testFilename = "{0}.tests.ps1" -f ($parts[0..($parts.Count-2)] -join '.')
-   
-                Write-Debug $testFilename
-    
-                if(Test-Path $testFilename) {
-                  $filename = $testFilename
-                }
-
-                Write-Debug $filename
-            }
-
-        } else {            
-            $fileName = [io.path]::GetTempFileName().Replace(".tmp", ".tests.ps1")
-            $psISE.CurrentFile.Editor.Text | Set-Content -Path $fileName 
-        }
-
-        Import-Module Pester
-
-        cls
-
-        Write-Debug $fileName
-        Invoke-Pester -relative_path $fileName
-
-        if(!$psISE.CurrentFile.IsSaved) { Remove-Item $fileName -Force -ErrorAction SilentlyContinue }
-    }
-    
     Remove-PesterMenu
-    [void]$psISE.CurrentPowerShellTab.AddOnsMenu.Submenus.Add("_Pester", $sb, "CTRL+F5") 
+    [void]$psISE.CurrentPowerShellTab.AddOnsMenu.Submenus.Add("_Pester", {IsePester\Invoke-IsePester}, "CTRL+F5")
 }
 
 function Get-PesterMenu {
@@ -52,6 +15,40 @@ function Remove-PesterMenu {
     if($menu) {
         [void]$psISE.CurrentPowerShellTab.AddOnsMenu.Submenus.Remove($menu)
     }
+}
+
+function Invoke-IsePester
+{
+    if(!$psISE.CurrentFile.IsUntitled) {
+        $psISE.CurrentFile.Save()
+
+        $fileName = $psISE.CurrentFile.FullPath
+
+        if($filename -notmatch '\.tests\.') {
+
+            $parts = $filename -split '\.'
+            $testFilename = "{0}.tests.ps1" -f ($parts[0..($parts.Count-2)] -join '.')
+
+            Write-Debug $testFilename
+
+            if(Test-Path $testFilename) {
+                $filename = $testFilename
+            }
+
+            Write-Debug $filename
+        }
+
+    } else {
+        $fileName = [io.path]::GetTempFileName().Replace(".tmp", ".tests.ps1")
+        $psISE.CurrentFile.Editor.Text | Set-Content -Path $fileName
+    }
+
+    Import-Module Pester
+
+    Write-Debug $fileName
+    Invoke-Pester -relative_path $fileName
+
+    if(!$psISE.CurrentFile.IsSaved) { Remove-Item $fileName -Force -ErrorAction SilentlyContinue }
 }
 
 Add-PesterMenu


### PR DESCRIPTION
Previously, a long script block was bound to a hotkey, and a call to cls was made to get that spam out of the console.  Now the hotkey is bound to a script block which just calls one command, removing the need for the cls, so you don't lose whatever previous output happened to be in the console.
